### PR TITLE
feat: status returns typed status, not string

### DIFF
--- a/src/sisyphus.rs
+++ b/src/sisyphus.rs
@@ -1,4 +1,3 @@
-use serde::{Deserialize, Serialize};
 use std::{
     future::{Future, IntoFuture},
     panic,

--- a/src/sisyphus.rs
+++ b/src/sisyphus.rs
@@ -260,17 +260,6 @@ pub trait Boulder: std::fmt::Display + Sized {
     where
         Self: 'static + Send + Sync + Sized;
 
-    /// Bootstrap the task state. This method will be called before the task spawn.
-    ///
-    /// Override this function if your task needs to to boostrap its state before
-    /// running spawn
-    fn bootstrap(self) -> Pin<Box<dyn Future<Output = eyre::Result<Self>> + Send>>
-    where
-        Self: 'static + Send + Sync + Sized,
-    {
-        Box::pin(async move { Ok(self) })
-    }
-
     /// Clean up the task state. This method will be called by the loop when
     /// the task is shutting down due to an unrecoverable error
     ///
@@ -297,7 +286,7 @@ pub trait Boulder: std::fmt::Display + Sized {
     /// Run the task until it panics. Errors result in a task restart with the
     /// same channels. This means that an error causes the task to lose only
     /// the data that is in-scope when it faults.
-    fn run_until_panic(mut self) -> Sisyphus
+    fn run_until_panic(self) -> Sisyphus
     where
         Self: 'static + Send + Sync + Sized,
     {
@@ -309,22 +298,6 @@ pub trait Boulder: std::fmt::Display + Sized {
         let restarts: Arc<AtomicUsize> = Default::default();
         let restarts_loop_ref = restarts.clone();
         let task: JoinHandle<()> = tokio::spawn(async move {
-            let res = self.bootstrap().await;
-            self = if let Err(err) = res {
-                let error_chain = err
-                    .chain()
-                    .map(|e| format!("[{}]", e.to_string()))
-                    .collect::<Vec<String>>()
-                    .join("->");
-                tracing::error!(err = %err, error_chain, task = task_description.as_str(), "Task encountered an Error during bootstrap");
-                let _ = tx.send(TaskStatus::Stopped {
-                    exceptional: true,
-                    err: Arc::new(err),
-                });
-                return;
-            } else {
-                res.unwrap()
-            };
             let handle = self.spawn(shutdown);
             tx.send(TaskStatus::Running)
                 .expect("Failed to send task status");
@@ -361,7 +334,6 @@ pub trait Boulder: std::fmt::Display + Sized {
                                 // We don't check the result of the send
                                 // because we're stopping regardless of
                                 // whether it worked
-                                let _ = tx.send(TaskStatus::Stopped{exceptional, err: Arc::new(err) });
                                 break;
                             }
 

--- a/src/sisyphus.rs
+++ b/src/sisyphus.rs
@@ -334,6 +334,7 @@ pub trait Boulder: std::fmt::Display + Sized {
                                 // We don't check the result of the send
                                 // because we're stopping regardless of
                                 // whether it worked
+                                let _ = tx.send(TaskStatus::Stopped{exceptional: false, err: Arc::new(eyre::eyre!("Shutdown"))});
                                 break;
                             }
 
@@ -343,11 +344,9 @@ pub trait Boulder: std::fmt::Display + Sized {
                                 // whether it worked
                                 // abort work
                                 handle.abort();
-                                tracing::trace!("Task received shutdown signal and aborted handle");
+                                tracing::trace!(task=task_description.as_str(), "Task received shutdown signal and aborted handle");
                                 // then  cleanup
                                 let _ = task.cleanup().await;
-                                // then set status to Stopped
-                                let _ = tx.send(TaskStatus::Stopped{exceptional: false, err: Arc::new(eyre::eyre!("Shutdown"))});
                                 break;
                             }
 


### PR DESCRIPTION
Make them more versatile for different cases. Also:
- fix: remove bootstrap lifecycle function because it interfered with spawn
- ref: make status return a type, not string